### PR TITLE
@types/react-router-dom: remove broken hooks export

### DIFF
--- a/types/react-router-dom/index.d.ts
+++ b/types/react-router-dom/index.d.ts
@@ -31,10 +31,6 @@ export {
     matchPath,
     withRouter,
     RouterChildContext,
-    useHistory,
-    useLocation,
-    useParams,
-    useRouteMatch,
 } from 'react-router';
 
 export interface BrowserRouterProps {


### PR DESCRIPTION
Per [https://github.com/ReactTraining/react-router/blob/master/packages/react-router/docs/api/hooks.md](https://github.com/ReactTraining/react-router/blob/master/packages/react-router/docs/api/hooks.md), hooks are imported from react-router-dom, not react-router. These attempted exports makes tsc fail in applications that use @types/react-router-dom with:

```
$ yarn typecheck
$ tsc --noEmit
node_modules/@types/react-router-dom/index.d.ts:34:5 - error TS2305: Module '"<path omitted>/node_modules/@types/react-router-dom/node_modules/@types/react-router"' has no exported member 'useHistory'.

34     useHistory,
       ~~~~~~~~~~

node_modules/@types/react-router-dom/index.d.ts:35:5 - error TS2305: Module '"<path omitted>/node_modules/@types/react-router-dom/node_modules/@types/react-router"' has no exported member 'useLocation'.

35     useLocation,
       ~~~~~~~~~~~

node_modules/@types/react-router-dom/index.d.ts:36:5 - error TS2305: Module '"<path omitted>/node_modules/@types/react-router-dom/node_modules/@types/react-router"' has no exported member 'useParams'.

36     useParams,
       ~~~~~~~~~

node_modules/@types/react-router-dom/index.d.ts:37:5 - error TS2305: Module '"<path omitted>/node_modules/@types/react-router-dom/node_modules/@types/react-router"' has no exported member 'useRouteMatch'.

37     useRouteMatch,
       ~~~~~~~~~~~~~


Found 4 errors.
```

Removing the lines makes tsc pass again.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `npm test`.)
^ not sure how to do this as a unit test rather than modifying the test runner for every single module >.>
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).
^This errors with `Error: Errors in typescript@next for external dependencies:
../react/index.d.ts(34,22): error TS2307: Cannot find module 'csstype'.` both in my branch and in current master >.>

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <https://github.com/ReactTraining/react-router/blob/master/packages/react-router/docs/api/hooks.md>
- [ ] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
^ I don't see how to do this? Also I don't know how this could have ever worked with react-router v5...